### PR TITLE
added SECURITY.md file

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,7 +20,7 @@ Example of details to include:
 
 We will acknowledge submissions as soon as we can, indicating the next steps in handling your report. After the initial reply to your report, the security team will endeavor to keep you informed of the progress towards a fix and full announcement, and may ask for additional information or guidance.
 
-Please note we operate a private bug bounty program and also accept submissions via this platform. Invitations for security researchers to the platform can be requested by emailing security@safetyculture.io.
+Please note we operate a private bug bounty program and also accept submissions via this platform. Invitations for security researchers to the platform can be requested by emailing security@safetyculture.com.
 
 ## Disclosure Policy
 


### PR DESCRIPTION
## SEC-766 - adding SECURITY.md file

PR to add SECURITY.md file to the repository. GitHub will use and display default files for any repository owned by the account that does not have its own file of that type. See URL link provided for more information. This will save adding the same security file to app repositories in the org.

SECURITY.md file contains existing contents used for the security.txt file one the main site.

https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file 