### PR TITLE
[EN-644] Create an organisation wide PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -12,6 +12,6 @@
 
 <!-- Does it make sense for this PR to be of this size? If the PR is large, consider breaking it down into smaller incremental PRs. To check the box, put an `x` in the box -->
 
-[ ] Is this PR a reasonable size?
+- [ ] Is this PR a reasonable size?
 
 <!-- Everyone merges their own PRs. Respond to reviewer feedback before merging. Try to avoid taking feedback personally. -->

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 ## Problem description
 
-## Pros/cons
+## Pros/cons of approach implemented
 <!-- Expectations for PRs: https://safetyculture.atlassian.net/wiki/spaces/ENG/pages/2881716914/RFC66+Pull+Request+Code+Review+Standards -->
 
 <!-- Have you included a short summary of what the PR does, a description of the problem being solved and the pros/cons of the approach? -->

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,8 @@
-## Description
+## Summary
+
+## Problem description
+
+## Pros/cons
 <!-- Expectations for PRs: https://safetyculture.atlassian.net/wiki/spaces/ENG/pages/2881716914/RFC66+Pull+Request+Code+Review+Standards -->
 
 <!-- Have you included a short summary of what the PR does, a description of the problem being solved and the pros/cons of the approach? -->

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,8 @@
-## Pull Request Guidelines for Authors
-
-Summary of [RFC66 - Pull Request & Code Review Standards](https://safetyculture.atlassian.net/wiki/spaces/ENG/pages/2881716914/RFC66+Pull+Request+Code+Review+Standards):
-
-<!-- Go over all the following points, and put an `x` in the boxes that are true -->
-- [ ] Have you included a short summary of what the PR does, a description of the problem being solved and the pros/cons of the approach?
-- [ ] Does it make sense for this PR to be of this size? If the PR is large, consider breaking it down into smaller incremental PRs.
-- Everyone merges their own PRs. Respond to reviewer feedback before merging. Try to avoid taking feedback personally.
-
 ## Description
+<!-- Expectations for PRs: [RFC66 - Pull Request & Code Review Standards](https://safetyculture.atlassian.net/wiki/spaces/ENG/pages/2881716914/RFC66+Pull+Request+Code+Review+Standards) -->
+
+<!-- Have you included a short summary of what the PR does, a description of the problem being solved and the pros/cons of the approach? -->
+
+<!-- Does it make sense for this PR to be of this size? If the PR is large, consider breaking it down into smaller incremental PRs. -->
+
+<!-- Everyone merges their own PRs. Respond to reviewer feedback before merging. Try to avoid taking feedback personally. -->

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -3,6 +3,8 @@
 
 <!-- Have you included a short summary of what the PR does, a description of the problem being solved and the pros/cons of the approach? -->
 
+## Checklist
 <!-- Does it make sense for this PR to be of this size? If the PR is large, consider breaking it down into smaller incremental PRs. -->
+[ ] Is this PR a reasonable size?
 
 <!-- Everyone merges their own PRs. Respond to reviewer feedback before merging. Try to avoid taking feedback personally. -->

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,7 @@
 
 Summary of [RFC66 - Pull Request & Code Review Standards](https://safetyculture.atlassian.net/wiki/spaces/ENG/pages/2881716914/RFC66+Pull+Request+Code+Review+Standards):
 
+<!-- Go over all the following points, and put an `x` in the boxes that are true -->
 - [ ] Have you included a short summary of what the PR does, a description of the problem being solved and the pros/cons of the approach?
 - [ ] Does it make sense for this PR to be of this size? If the PR is large, consider breaking it down into smaller incremental PRs.
 - Everyone merges their own PRs. Respond to reviewer feedback before merging. Try to avoid taking feedback personally.

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 ## Description
-<!-- Expectations for PRs: [RFC66 - Pull Request & Code Review Standards](https://safetyculture.atlassian.net/wiki/spaces/ENG/pages/2881716914/RFC66+Pull+Request+Code+Review+Standards) -->
+<!-- Expectations for PRs: https://safetyculture.atlassian.net/wiki/spaces/ENG/pages/2881716914/RFC66+Pull+Request+Code+Review+Standards -->
 
 <!-- Have you included a short summary of what the PR does, a description of the problem being solved and the pros/cons of the approach? -->
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-# Pull Request Guidelines for Authors
+## Pull Request Guidelines for Authors
 
 Summary of [RFC66 - Pull Request & Code Review Standards](https://safetyculture.atlassian.net/wiki/spaces/ENG/pages/2881716914/RFC66+Pull+Request+Code+Review+Standards):
 
@@ -6,3 +6,5 @@ Summary of [RFC66 - Pull Request & Code Review Standards](https://safetyculture.
 - [ ] Have you included a short summary of what the PR does, a description of the problem being solved and the pros/cons of the approach?
 - [ ] Does it make sense for this PR to be of this size? If the PR is large, consider breaking it down into smaller incremental PRs.
 - Everyone merges their own PRs. Respond to reviewer feedback before merging. Try to avoid taking feedback personally.
+
+## Description

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,17 @@
+<!-- Expectations for PRs: https://safetyculture.atlassian.net/wiki/spaces/ENG/pages/2881716914/RFC66+Pull+Request+Code+Review+Standards -->
+
+<!-- Have you included a short summary of what the PR does, a description of the problem being solved and the pros/cons of the approach? -->
+
 ## Summary
 
 ## Problem description
 
 ## Pros/cons of approach implemented
-<!-- Expectations for PRs: https://safetyculture.atlassian.net/wiki/spaces/ENG/pages/2881716914/RFC66+Pull+Request+Code+Review+Standards -->
-
-<!-- Have you included a short summary of what the PR does, a description of the problem being solved and the pros/cons of the approach? -->
 
 ## Checklist
-<!-- Does it make sense for this PR to be of this size? If the PR is large, consider breaking it down into smaller incremental PRs. -->
+
+<!-- Does it make sense for this PR to be of this size? If the PR is large, consider breaking it down into smaller incremental PRs. To check the box, put an `x` in the box -->
+
 [ ] Is this PR a reasonable size?
 
 <!-- Everyone merges their own PRs. Respond to reviewer feedback before merging. Try to avoid taking feedback personally. -->

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+# Pull Request Guidelines for Authors
+
+Summary of [RFC66 - Pull Request & Code Review Standards](https://safetyculture.atlassian.net/wiki/spaces/ENG/pages/2881716914/RFC66+Pull+Request+Code+Review+Standards):
+
+- [ ] Have you included a short summary of what the PR does, a description of the problem being solved and the pros/cons of the approach?
+- [ ] Does it make sense for this PR to be of this size? If the PR is large, consider breaking it down into smaller incremental PRs.
+- Everyone merges their own PRs. Respond to reviewer feedback before merging. Try to avoid taking feedback personally.


### PR DESCRIPTION
This is a base template for authors when raising a PR. It is short summary of what we expect from authors when raising a PR as per [RFC66](https://safetyculture.atlassian.net/wiki/spaces/ENG/pages/2881716914/RFC66+Pull+Request+Code+Review+Standards).

According to https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file, this should apply this as a base PR template across the Organisation. If repositories have their own PR template, it should override this template. 