### PR TITLE
Add code review guidelines for reviewers into PR template rather than…

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,12 @@
 <!-- Expectations for PRs: https://safetyculture.atlassian.net/wiki/spaces/ENG/pages/2881716914/RFC66+Pull+Request+Code+Review+Standards -->
 
-<!-- Have you included a short summary of what the PR does, a description of the problem being solved and the pros/cons of the approach? -->
-
 ## Summary
 
+<!-- Short summary of what the PR does -->
+
 ## Problem description
+
+<!-- Description of the problem being solved -->
 
 ## Pros/cons of approach implemented
 
@@ -15,3 +17,12 @@
 - [ ] Is this PR a reasonable size?
 
 <!-- Everyone merges their own PRs. Respond to reviewer feedback before merging. Try to avoid taking feedback personally. -->
+
+---
+
+**Code Review Guidelines** for Reviewers
+
+- Try to review in a timely manner. Opinions/nitpicks should not be blockers. Pair on a call for non-trivial feedback.
+- Overall design and approach should follow established patterns. Don't try to make the PR perfect.
+- Try to identify edge cases, race conditions, over-engineering, lack of test coverage and complexity.
+- If you don't feel qualified to review the code, pass it on to someone who is.


### PR DESCRIPTION
<!-- Expectations for PRs: https://safetyculture.atlassian.net/wiki/spaces/ENG/pages/2881716914/RFC66+Pull+Request+Code+Review+Standards -->

## Summary

Migrate code review guidelines for reviewers into PR template after reverting change to have these added as comments on all PRs.

## Problem description

Adding comments on all PRs turned out to be quite noisy, particularly with the slack and email notifications from Github

## Pros/cons of approach implemented
- The PR template is filled in by Authors, so adding a section for reviewers may not be as effective as commenting.
## Checklist

- [x] Is this PR a reasonable size?

<!-- Everyone merges their own PRs. Respond to reviewer feedback before merging. Try to avoid taking feedback personally. -->

---

**Code Review Guidelines** for Reviewers

- Try to review in a timely manner. Opinions/nitpicks should not be blockers. Pair on a call for non-trivial feedback.
- Overall design and approach should follow established patterns. Don't try to make the PR perfect.
- Try to identify edge cases, race conditions, over-engineering, lack of test coverage and complexity.
- If you don't feel qualified to review the code, pass it on to someone who is.
