### PR TITLE
[AIA-382] chore: disable Claude Code experimental betas

### DIFF
--- a/workflow-templates/claude.yaml
+++ b/workflow-templates/claude.yaml
@@ -34,6 +34,7 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         env:
+          CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
           ANTHROPIC_BASE_URL: ${{ vars.LITELLM_BASE_URL }}
           ANTHROPIC_CUSTOM_HEADERS: 'sc-user-id: ${{ vars.LITELLM_SC_USER_ID }}|${{ github.event.repository.name }}'
         with:


### PR DESCRIPTION
## Summary
- Add `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"` environment variable to Claude Code Action workflow step(s)

## Files changed
- `workflow-templates/claude.yaml`

## Why
Disable experimental beta features in Claude Code GitHub Action to ensure stable, predictable behaviour.
