### PR TITLE
chore: rename engineering-productivity codeowner to platform [ENP-5121]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # https://help.github.com/articles/about-codeowners/
 
-* @SafetyCulture/engineering-productivity
+* @SafetyCulture/platform


### PR DESCRIPTION
## Summary
Renames `@SafetyCulture/engineering-productivity` to `@SafetyCulture/platform` in CODEOWNERS to reflect the team rename.

Part of [ENP-5121](https://safetyculture.atlassian.net/browse/ENP-5121).

## Test plan
- [ ] CODEOWNERS syntax validated by GitHub (no parse errors reported on PR)
- [ ] No unintended owner removals


[ENP-5121]: https://safetyculture.atlassian.net/browse/ENP-5121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ